### PR TITLE
fixing unbound local variable

### DIFF
--- a/grafana.sh
+++ b/grafana.sh
@@ -292,7 +292,7 @@ set_datasources() {
 
 
 set_seed_secrets() {
-    if [[ -z "${SECRET_KEY}" ]]
+    if [[ -z "${SECRET_KEY-}" ]]
     then
         # Take it from the space_id. It is not random!
         export SECRET_KEY=$(jq -r '.space_id' <<<"${VCAP_APPLICATION}")


### PR DESCRIPTION
With respect to issue #2 

Fixing Unbound local variable issue on SECRET_KEY while running the grafana buildpack.