### PR TITLE
Include full postgresql uri schema identifier

### DIFF
--- a/grafana.sh
+++ b/grafana.sh
@@ -166,7 +166,7 @@ set_env_DB() {
         DB_TLS="false"
     elif [[ "${DB_TYPE}" == "postgres" ]]
     then
-        DB_PORT="5444"
+        DB_PORT="5432"
         uri="${uri}:${DB_PORT}"
         DB_TLS="disable"
     fi

--- a/grafana.sh
+++ b/grafana.sh
@@ -173,8 +173,7 @@ set_env_DB() {
     if ! DB_NAME=$(jq -r -e '.credentials.database_name' <<<"${db}")
     then
         DB_NAME=$(jq -r -e '.credentials.uri |
-            split("://")[1] | split(":")[1] |
-            split("@")[1] | split("/")[1] |
+            split("://")[1] | split("/")[1] |
             split("?")[0]' <<<"${db}") || DB_NAME=''
     fi
     uri="${uri}/${DB_NAME}"

--- a/grafana.sh
+++ b/grafana.sh
@@ -166,7 +166,7 @@ set_env_DB() {
         DB_TLS="false"
     elif [[ "${DB_TYPE}" == "postgres" ]]
     then
-        DB_PORT="5432"
+        DB_PORT="5444"
         uri="${uri}:${DB_PORT}"
         DB_TLS="disable"
     fi

--- a/grafana.sh
+++ b/grafana.sh
@@ -132,6 +132,11 @@ set_env_DB() {
     local uri=""
 
     DB_TYPE=$(get_db_vcap_service_type "${db}")
+    if [[ DB_TYPE == "postgresql" ]]
+    then
+	DB_TYPE="postgres"
+    fi
+
     uri="${DB_TYPE}://"
     if ! DB_USER=$(jq -r -e '.credentials.Username' <<<"${db}")
     then

--- a/grafana.sh
+++ b/grafana.sh
@@ -93,7 +93,7 @@ get_db_vcap_service() {
     if [[ -z "${binding_name}" ]] || [[ "${binding_name}" == "null" ]]
     then
         # search for a sql service looking at the label
-        jq '[.[][] | select(.credentials.uri) | select(.credentials.uri | split(":")[0] == ("mysql","postgres"))] | first | select (.!=null)' <<<"${VCAP_SERVICES}"
+        jq '[.[][] | select(.credentials.uri) | select(.credentials.uri | split(":")[0] == ("mysql","postgres","postgresql"))] | first | select (.!=null)' <<<"${VCAP_SERVICES}"
     else
         get_binding_service "${binding_name}"
     fi
@@ -132,7 +132,7 @@ set_env_DB() {
     local uri=""
 
     DB_TYPE=$(get_db_vcap_service_type "${db}")
-    if [[ DB_TYPE == "postgresql" ]]
+    if [[ $DB_TYPE == "postgresql" ]]
     then
 	DB_TYPE="postgres"
     fi


### PR DESCRIPTION
## Summary
Allow `postgresql://` schema identifier.

## Rationale
Postgresql uri schemas can have both `postgres` or `postgresql` as schema identifier. So for example:

* `postgres://user:pass@localhost:5432/db`
* `postgresql://user:pass@localhost:5432/db`

are both valid.

This PR attempts to fix this for (custom) CF services which use the latter of the two schema's.