### PR TITLE
fix: modify postgres port

### DIFF
--- a/grafana.sh
+++ b/grafana.sh
@@ -166,14 +166,14 @@ set_env_DB() {
         DB_TLS="false"
     elif [[ "${DB_TYPE}" == "postgres" ]]
     then
-        if ! DB_PORT=$(jq -r -e '.credentials.port' <<<"${db}")
+      if ! DB_PORT=$(jq -r -e '.credentials.port' <<<"${db}")
     	then
    			DB_PORT=$(jq -r -e '.credentials.uri |
-           		split("://")[1] | split(":")[1] |
-           		split("@")[1] | split(":")[1] | split("/")[0]' <<<"${db}") || DB_PORT='' 
+          split("://")[1] | split(":")[1] |
+          split("@")[1] | split(":")[1] | split("/")[0]' <<<"${db}") || DB_PORT='' 
    		fi
-        uri="${uri}:${DB_PORT}"
-        DB_TLS="disable"
+      uri="${uri}:${DB_PORT}"
+      DB_TLS="disable"
     fi
     if ! DB_NAME=$(jq -r -e '.credentials.database_name' <<<"${db}")
     then

--- a/grafana.sh
+++ b/grafana.sh
@@ -167,11 +167,11 @@ set_env_DB() {
     elif [[ "${DB_TYPE}" == "postgres" ]]
     then
       if ! DB_PORT=$(jq -r -e '.credentials.port' <<<"${db}")
-    	then
-   			DB_PORT=$(jq -r -e '.credentials.uri |
-          split("://")[1] | split(":")[1] |
-          split("@")[1] | split(":")[1] | split("/")[0]' <<<"${db}") || DB_PORT='' 
-   		fi
+      then
+          DB_PORT=$(jq -r -e '.credentials.uri |
+            split("://")[1] | split(":")[1] |
+            split("@")[1] | split(":")[1] | split("/")[0]' <<<"${db}") || DB_PORT='' 
+      fi
       uri="${uri}:${DB_PORT}"
       DB_TLS="disable"
     fi

--- a/grafana.sh
+++ b/grafana.sh
@@ -166,7 +166,12 @@ set_env_DB() {
         DB_TLS="false"
     elif [[ "${DB_TYPE}" == "postgres" ]]
     then
-        DB_PORT="5432"
+        if ! DB_PORT=$(jq -r -e '.credentials.port' <<<"${db}")
+    	then
+   			DB_PORT=$(jq -r -e '.credentials.uri |
+           		split("://")[1] | split(":")[1] |
+           		split("@")[1] | split(":")[1] | split("/")[0]' <<<"${db}") || DB_PORT='' 
+   		fi
         uri="${uri}:${DB_PORT}"
         DB_TLS="disable"
     fi


### PR DESCRIPTION
The Grafana script initially had the PostgreSQL port configured as 5432, but when connecting to PostgreSQL in Cloud Foundry, the port number was different. So, I made modifications to the code so that it retrieves the port number from credentials, and if not available, it will extract it from the URI.